### PR TITLE
Trivia visual polish, download retry logic, and failed-song handling

### DIFF
--- a/src/main/trivial-generator/trivial.css.ejs
+++ b/src/main/trivial-generator/trivial.css.ejs
@@ -1265,6 +1265,32 @@
         box-shadow: inset 0 -70px 40px -25px rgba(11, 18, 41, 0.9);
     }
 
+    [name="song-panel"][data-error="true"] {
+        cursor: not-allowed;
+        filter: grayscale(0.7);
+        opacity: 0.5;
+        border-color: var(--panel-border) !important;
+    }
+
+    [name="song-panel"][data-error="true"]:hover {
+        transform: none;
+    }
+
+    [name="song-panel"][data-error="true"]::before {
+        content: "\2715";
+        font-size: 3rem;
+        color: var(--crimson);
+        opacity: 0.5;
+    }
+
+    [name="song-panel"][data-error="true"]::after {
+        content: "Unavailable";
+        color: var(--crimson);
+        opacity: 1;
+        left: 0.65rem;
+        right: auto;
+    }
+
     [name="song-panel"] span.font-bold {
         position: absolute;
         top: 0.5rem;
@@ -1284,7 +1310,7 @@
         color: var(--panel-tint);
     }
 
-    #div-scoreboard button {
+    .add-player-btn {
         font-family: "Anton", sans-serif;
         text-transform: uppercase;
         letter-spacing: 0.03em;
@@ -1295,7 +1321,7 @@
         transition: transform 0.12s ease;
     }
 
-    #div-scoreboard button:active {
+    .add-player-btn:active {
         transform: scale(0.95);
     }
 
@@ -1303,6 +1329,114 @@
         background: var(--panel) !important;
         border: 2px solid var(--panel-border) !important;
         border-radius: 0.5rem;
+    }
+
+    .player-name-input {
+        border: 1px solid var(--panel-border);
+        border-radius: 0.3rem;
+        color: var(--cream);
+        transition: border-color 0.12s ease;
+    }
+
+    .player-name-input:focus {
+        outline: none;
+        border-color: var(--gold);
+    }
+
+    .player-name-input::placeholder {
+        color: rgba(244, 236, 216, 0.4);
+    }
+
+    .player-name-input:disabled {
+        border-color: transparent;
+        color: var(--cream);
+    }
+
+    .player-icon-btn {
+        background: transparent;
+        border-radius: 0.3rem;
+        transition:
+            transform 0.12s ease,
+            background 0.12s ease;
+    }
+
+    .player-icon-btn:hover {
+        background: rgba(244, 236, 216, 0.08);
+    }
+
+    .player-icon-btn:active {
+        transform: scale(0.9);
+    }
+
+    .score-number {
+        font-family: "Anton", sans-serif;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--stage-bg);
+        border: 1px solid var(--panel-border);
+        color: var(--cream);
+    }
+
+    .score-btn {
+        font-family: "Anton", sans-serif;
+        color: var(--cream);
+        transition:
+            transform 0.12s ease,
+            box-shadow 0.12s ease;
+    }
+
+    .score-btn:hover {
+        box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
+    }
+
+    .score-btn:active {
+        transform: scale(0.9);
+    }
+
+    .score-btn-minus {
+        background: var(--crimson) !important;
+    }
+
+    .score-btn-plus {
+        background: var(--emerald) !important;
+    }
+
+    #volume-range {
+        -webkit-appearance: none;
+        appearance: none;
+        height: 4px;
+        border-radius: 9999px;
+        background: rgba(244, 236, 216, 0.15);
+        outline: none;
+    }
+
+    #volume-range::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 14px;
+        height: 14px;
+        border-radius: 9999px;
+        background: var(--gold);
+        border: 2px solid var(--stage-bg);
+        box-shadow: 0 0 6px rgba(240, 176, 46, 0.6);
+        cursor: pointer;
+    }
+
+    #volume-range::-moz-range-thumb {
+        width: 14px;
+        height: 14px;
+        border-radius: 9999px;
+        background: var(--gold);
+        border: 2px solid var(--stage-bg);
+        box-shadow: 0 0 6px rgba(240, 176, 46, 0.6);
+        cursor: pointer;
+    }
+
+    #volume-range::-moz-range-track {
+        height: 4px;
+        border-radius: 9999px;
+        background: rgba(244, 236, 216, 0.15);
     }
 
     #modal-overlay .bg-white {
@@ -1316,6 +1450,22 @@
         text-transform: uppercase;
         letter-spacing: 0.03em;
         color: var(--gold) !important;
+    }
+
+    .modal-body {
+        font-family: "Archivo", sans-serif;
+        color: var(--cream);
+    }
+
+    .modal-body ul {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+    }
+
+    .modal-label {
+        font-weight: 700;
+        color: var(--gold);
     }
 
     #ok-btn {

--- a/src/main/trivial-generator/trivial.player.ejs
+++ b/src/main/trivial-generator/trivial.player.ejs
@@ -11,16 +11,16 @@
 
         const newPlayer = `<div id="player-${newPlayerNumber}" name="player" class="flex justify-start border gap-0 border-black rounded w-full bg-sky-300 p-2">
             <div class="w-9/12" id="div-name-${newPlayerNumber}">
-            <input id="name-${newPlayerNumber}" type="text" placeholder="New player" class="px-1 bg-transparent w-full" onkeydown="enterName(event);">
+            <input id="name-${newPlayerNumber}" type="text" placeholder="New player" class="player-name-input px-1 bg-transparent w-full" onkeydown="enterName(event);">
             </div>
             <div>
-            <button onclick="confirmPlayer(this);" id="confirm-player-${newPlayerNumber}">✅</button>
-            <button onclick="deletePlayer(this);" id="delete-player-${newPlayerNumber}">❌</button>
+            <button class="player-icon-btn" onclick="confirmPlayer(this);" id="confirm-player-${newPlayerNumber}">✅</button>
+            <button class="player-icon-btn" onclick="deletePlayer(this);" id="delete-player-${newPlayerNumber}">❌</button>
             </div>
             <div id="score-player-${newPlayerNumber}" class="flex justify-end gap-0 w-24 box-border" style="display:none">
-            <button id="score-minus-${newPlayerNumber}" class="bg-red-600 w-5 h-6 rounded-tl rounded-bl" onclick="editScore(this, 'remove');"> - </button>
-            <span id="score-number-${newPlayerNumber}" class="text-center w-8 h-6 border border-black"> 0 </span>
-            <button id="score-plus-${newPlayerNumber}" class="bg-green-600 w-5 h-6 rounded-tr rounded-br" onclick="editScore(this, 'add');"> + </button>
+            <button id="score-minus-${newPlayerNumber}" class="score-btn score-btn-minus w-5 h-6 rounded-tl rounded-bl" onclick="editScore(this, 'remove');"> - </button>
+            <span id="score-number-${newPlayerNumber}" class="score-number text-center w-8 h-6"> 0 </span>
+            <button id="score-plus-${newPlayerNumber}" class="score-btn score-btn-plus w-5 h-6 rounded-tr rounded-br" onclick="editScore(this, 'add');"> + </button>
             </div>
         </div>`;
         playersDiv.insertAdjacentHTML("beforeend", newPlayer);

--- a/src/main/trivial-generator/trivial.template.ejs
+++ b/src/main/trivial-generator/trivial.template.ejs
@@ -14,16 +14,16 @@
 
         <!-- Modal Content -->
         <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
-            <div class="font-mono mt-3">
-                <h3 class="text-lg text-center leading-6 font-medium text-gray-900">Información extra:</h3>
+            <div class="modal-body mt-3">
+                <h3 class="text-lg text-center leading-6 font-medium text-gray-900">Extra info:</h3>
                 <div class="mt-2 px-7 py-3">
                     <ul>
-                        <li style="display:none;"><span class="font-bold">Anime: </span><span id="modal-anime"></span></li>
-                        <li style="display:none;"><span class="font-bold">Juego: </span><span id="modal-game"></span></li>
-                        <li style="display:none;"><span class="font-bold">Saga: </span><span id="modal-saga"></span></li>
-                        <li style="display:none;"><span class="font-bold">Tipo: </span><span id="modal-oped"></span></li>
-                        <li style="display:none;"><span class="font-bold">Banda: </span><span id="modal-band"></span></li>
-                        <li style="display:none;"><span class="font-bold">Canción: </span><span id="modal-song"></span></li>
+                        <li style="display:none;"><span class="modal-label">Anime: </span><span id="modal-anime"></span></li>
+                        <li style="display:none;"><span class="modal-label">Game: </span><span id="modal-game"></span></li>
+                        <li style="display:none;"><span class="modal-label">Saga: </span><span id="modal-saga"></span></li>
+                        <li style="display:none;"><span class="modal-label">Type: </span><span id="modal-oped"></span></li>
+                        <li style="display:none;"><span class="modal-label">Band: </span><span id="modal-band"></span></li>
+                        <li style="display:none;"><span class="modal-label">Song: </span><span id="modal-song"></span></li>
                     </ul>
                 </div>
                 <div class="items-center px-4 py-3">
@@ -65,7 +65,7 @@
 
             <div id="div-scoreboard" class="w-full">
                 <button
-                    class="w-28 p-1 flex mx-auto border border-black shadow-sm text-sm font-medium rounded-md text-white bg-teal-500 hover:bg-teal-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    class="add-player-btn w-28 p-1 flex mx-auto border border-black shadow-sm text-sm font-medium rounded-md text-white bg-teal-500 hover:bg-teal-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
                     onclick="addPlayer()">
                     <span class="w-full text-center">Add player</span>
                 </button>
@@ -85,8 +85,8 @@
                 };
                     songs.forEach((song, index) => { %>
                         <div id="<%= song.id %>"  data-embeddable="<%= song.isEmbeddable %>" data-error="<%= song.isError %>" data-difficulty="<%= song.difficulty %>" name="song-panel"
-                    class="border-4 <%= DIFFICULTY_COLORS[song.difficulty] %> xl:basis-56 lg:basis-52 bg-no-repeat bg-center bg-cover relative basis-60 flex-shrink-0 h-[10rem] pl-1
-                        <%= song.isError ? " bg-black" : "" %>" onclick="toggleAudio(this.id);">
+                    class="border-4 <%= DIFFICULTY_COLORS[song.difficulty] %> xl:basis-56 lg:basis-52 bg-no-repeat bg-center bg-cover relative basis-60 flex-shrink-0 h-[10rem] pl-1"
+                        <%= song.isError ? "" : `onclick="toggleAudio(this.id);"` %>>
                             <span class="font-bold"><%= index + 1 %></span>
                             <span id="anime-<%=song.id%>" class="hidden font-mono absolute bottom-0 left-0 px-1 w-full bg-black text-white">
                                 <%= trivialType === "anime" ? song.anime : trivialType === "game" ? song.game : song.name %>

--- a/src/main/trivial-generator/youtube-downloader.ts
+++ b/src/main/trivial-generator/youtube-downloader.ts
@@ -9,6 +9,13 @@ type DownloadAudioParams = {
   songId: string;
 };
 
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 2000;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function downloadAudio({ outputDir, songId }: DownloadAudioParams) {
   if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir);
 
@@ -24,31 +31,42 @@ export async function downloadAudio({ outputDir, songId }: DownloadAudioParams) 
     else return false;
   }
 
-  try {
-    const ytDlpWrap = await getYtDlpWrap();
+  const ytDlpWrap = await getYtDlpWrap();
 
-    // Electron's own binary satisfies yt-dlp's Node>=22 requirement when run
-    // with ELECTRON_RUN_AS_NODE, so no separate JS runtime needs to be bundled.
-    await ytDlpWrap.execPromise(
-      [
-        `https://youtu.be/${songId}`,
-        "-f",
-        "bestaudio",
-        "-o",
-        fullPath,
-        "--no-playlist",
-        "--js-runtimes",
-        `node:${process.execPath}`
-      ],
-      { env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" } }
-    );
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      // Electron's own binary satisfies yt-dlp's Node>=22 requirement when run
+      // with ELECTRON_RUN_AS_NODE, so no separate JS runtime needs to be bundled.
+      await ytDlpWrap.execPromise(
+        [
+          `https://youtu.be/${songId}`,
+          "-f",
+          "bestaudio",
+          "-o",
+          fullPath,
+          "--no-playlist",
+          "--js-runtimes",
+          `node:${process.execPath}`
+        ],
+        { env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" } }
+      );
 
-    console.log(`${songId} downloaded`);
-    return true;
-  } catch (err) {
-    const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
-    console.error(`Error downloading ${songId} -- ${message}`);
-    logToFile(`Error downloading ${songId} -- ${message}`);
-    return false;
+      console.log(`${songId} downloaded`);
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+      const attemptLabel = `attempt ${attempt}/${MAX_ATTEMPTS}`;
+      console.error(`Error downloading ${songId} (${attemptLabel}) -- ${message}`);
+      logToFile(`Error downloading ${songId} (${attemptLabel}) -- ${message}`);
+
+      // yt-dlp can fail after partially writing the output file; clear it so
+      // the next attempt (or the existsSync check on a future run) doesn't
+      // mistake a partial/empty file for a completed download.
+      if (fs.existsSync(fullPath)) fs.rmSync(fullPath);
+
+      if (attempt < MAX_ATTEMPTS) await sleep(RETRY_DELAY_MS);
+    }
   }
+
+  return false;
 }

--- a/src/renderer/src/pages/index/dialogs/completed.dialog.tsx
+++ b/src/renderer/src/pages/index/dialogs/completed.dialog.tsx
@@ -12,6 +12,7 @@ import { Step, STEPS } from "./dialog.constants";
 
 type CompletedDialogProps = {
   outputDir: string;
+  failedIds: Array<string>;
   setStep: Dispatch<SetStateAction<Step>>;
   setUnembeddableIds: Dispatch<SetStateAction<Array<string>>>;
   setFailedIds: Dispatch<SetStateAction<Array<string>>>;
@@ -19,6 +20,7 @@ type CompletedDialogProps = {
 
 export default function CompletedDialog({
   outputDir,
+  failedIds,
   setStep,
   setUnembeddableIds,
   setFailedIds
@@ -43,6 +45,12 @@ export default function CompletedDialog({
           <DialogTitle>Trivial Generated</DialogTitle>
           <DialogDescription>The trivial was generated successfully</DialogDescription>
         </DialogHeader>
+        {failedIds.length > 0 && (
+          <p className="text-sm text-destructive">
+            {failedIds.length} song{failedIds.length > 1 ? "s" : ""} couldn't be downloaded and
+            will show as unavailable in the generated trivial.
+          </p>
+        )}
         <Button variant="secondary" onClick={() => window.api.shell.openPath(trivialPath)}>
           Open Trivial
         </Button>

--- a/src/renderer/src/pages/index/generation.dialog.tsx
+++ b/src/renderer/src/pages/index/generation.dialog.tsx
@@ -81,6 +81,7 @@ export default function ProgressDialog({
     return (
       <CompletedDialog
         outputDir={outputDir}
+        failedIds={failedIds}
         setFailedIds={setFailedIds}
         setStep={setStep}
         setUnembeddableIds={setUnembeddableIds}

--- a/src/renderer/src/pages/list-editor/table/actions-cell.tsx
+++ b/src/renderer/src/pages/list-editor/table/actions-cell.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 
-import { Trash2 } from "lucide-react";
+import { ChevronUp, ChevronDown, Trash2 } from "lucide-react";
 import { ListEditorTableMeta } from "./list-editor-table";
 
 type ArrowButtonProps = {
@@ -11,7 +11,7 @@ type ArrowButtonProps = {
 };
 
 const ArrowButton = ({ rowIndex, rowAmount, direction, moveRowFunction }: ArrowButtonProps) => {
-  const arrow = direction === "up" ? "▲" : "▼";
+  const Icon = direction === "up" ? ChevronUp : ChevronDown;
 
   if (direction === "up" && rowIndex === 0) {
     return null;
@@ -26,7 +26,7 @@ const ArrowButton = ({ rowIndex, rowAmount, direction, moveRowFunction }: ArrowB
       className="text-muted-foreground hover:text-primary p-0 focus:outline-none"
       onClick={() => moveRowFunction(rowIndex)}
     >
-      {arrow}
+      <Icon size={16} />
     </button>
   );
 };

--- a/src/renderer/src/pages/list-editor/table/thumbnail-cell.tsx
+++ b/src/renderer/src/pages/list-editor/table/thumbnail-cell.tsx
@@ -2,5 +2,18 @@
 export const ThumbnailCell = ({ row }) => {
   const { id: videoId } = row.original;
 
-  return <img className="h-12 w-12" src={`http://img.youtube.com/vi/${videoId}/0.jpg`} />;
+  if (!videoId) {
+    return <div className="h-12 w-12 rounded border-2 border-border bg-muted" />;
+  }
+
+  return (
+    <img
+      className="h-12 w-12 rounded border-2 border-border object-cover"
+      alt=""
+      src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
+      onError={(e) => {
+        e.currentTarget.style.visibility = "hidden";
+      }}
+    />
+  );
 };


### PR DESCRIPTION
## Summary
- Re-theme the remaining unstyled corners of the generated trivia game: info modal (was raw white/gray/green with Spanish labels), score +/- buttons, player name input, volume slider.
- Replace raw ▲▼ text glyphs with themed lucide icons in the song table, and fix a stale `http://.../0.jpg` thumbnail URL (letterboxing + insecure protocol) with proper fallback/alt handling.
- Add automatic retry (3 attempts, 2s apart) to song audio downloads — transient YouTube `403` errors were previously permanent failures for the whole generation run.
- Songs that still fail after retries now render clearly disabled in the generated trivia (grayscale, non-interactive, red ✕, "Unavailable" label) instead of a plain black tile with no explanation.
- The "Trivial Generated" completion dialog now reports how many songs failed to download instead of silently declaring success.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build:win` produces a working portable exe
- [x] Verified all visual changes via Playwright screenshots of the rendered trivia template (score button colors, modal theming, disabled-song tile)
- [x] Reproduced the original 403 failure via yt-dlp CLI and confirmed a retry succeeds
- [ ] Manual smoke test of the built exe by the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)