### PR TITLE
Persist trivia game state (players, scores, revealed songs)

### DIFF
--- a/src/main/trivial-generator/trivial.css.ejs
+++ b/src/main/trivial-generator/trivial.css.ejs
@@ -1325,6 +1325,27 @@
         transform: scale(0.95);
     }
 
+    .reset-game-btn {
+        font-family: "Anton", sans-serif;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        border: 2px solid var(--panel-border) !important;
+        background: transparent !important;
+        color: var(--cream) !important;
+        transition:
+            transform 0.12s ease,
+            border-color 0.12s ease;
+    }
+
+    .reset-game-btn:hover {
+        border-color: var(--crimson) !important;
+        color: var(--crimson) !important;
+    }
+
+    .reset-game-btn:active {
+        transform: scale(0.95);
+    }
+
     [name="player"] {
         background: var(--panel) !important;
         border: 2px solid var(--panel-border) !important;

--- a/src/main/trivial-generator/trivial.player.ejs
+++ b/src/main/trivial-generator/trivial.player.ejs
@@ -65,12 +65,16 @@
 
         const scoreDiv = document.getElementById(`score-player-${playerNumber}`);
         scoreDiv.style.display = "flex";
+
+        saveGameState();
     }
 
     function deletePlayer(button) {
         const playerNumber = getPlayerNumber(button);
         const player = document.getElementById(`player-${playerNumber}`);
         player.remove();
+
+        saveGameState();
     }
 
     function editScore(button, mode) {
@@ -81,5 +85,7 @@
         const newScore = mode == "add" ? score + 1 : score - 1;
 
         scoreNumber.innerHTML = newScore;
+
+        saveGameState();
     }
 </script>

--- a/src/main/trivial-generator/trivial.template.ejs
+++ b/src/main/trivial-generator/trivial.template.ejs
@@ -64,11 +64,19 @@
             </div>
 
             <div id="div-scoreboard" class="w-full">
-                <button
-                    class="add-player-btn w-28 p-1 flex mx-auto border border-black shadow-sm text-sm font-medium rounded-md text-white bg-teal-500 hover:bg-teal-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                    onclick="addPlayer()">
-                    <span class="w-full text-center">Add player</span>
-                </button>
+                <div class="flex gap-2 justify-center">
+                    <button
+                        class="add-player-btn w-28 p-1 flex border border-black shadow-sm text-sm font-medium rounded-md text-white bg-teal-500 hover:bg-teal-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                        onclick="addPlayer()">
+                        <span class="w-full text-center">Add player</span>
+                    </button>
+
+                    <button
+                        class="reset-game-btn w-28 p-1 flex border text-sm font-medium rounded-md focus:outline-none"
+                        onclick="resetGame()">
+                        <span class="w-full text-center">Reset game</span>
+                    </button>
+                </div>
 
                 <div id="players" class="w-full mt-2">
 
@@ -270,19 +278,109 @@
             currentError = null;
         }
 
-        function reveal() {
-            if (currentId == "") return;
+        function markRevealed(songId) {
+            const div = document.getElementById(songId);
+            if (!div) return;
 
-            const div = document.getElementById(currentId);
-            const answer = document.getElementById(`anime-${currentId}`);
-
+            const answer = document.getElementById(`anime-${songId}`);
             answer.classList.remove("hidden");
 
             div.classList.add("revealed");
             div.style.backgroundImage =
-                "url('https://img.youtube.com/vi/" + currentId + "/hqdefault.jpg')";
-            removeFocus(currentId);
+                "url('https://img.youtube.com/vi/" + songId + "/hqdefault.jpg')";
         }
+
+        function reveal() {
+            if (currentId == "") return;
+
+            markRevealed(currentId);
+            removeFocus(currentId);
+            saveGameState();
+        }
+
+        // ************
+        //  PERSISTENCE
+        // ************
+        // Chromium shares one localStorage bucket across every file:// page
+        // regardless of path or filename, so the key itself -- not the file
+        // location -- is what keeps different generated trivials from
+        // clobbering each other's saved state.
+        let isRestoringState = false;
+
+        function getSongSignature() {
+            return songs.map((song) => song.id).join("|");
+        }
+
+        function getStorageKey() {
+            return `trivial-game-state:${getSongSignature()}`;
+        }
+
+        function saveGameState() {
+            if (isRestoringState) return;
+
+            const players = Array.from(document.getElementsByName("player")).map((playerDiv) => {
+                const number = getPlayerNumber(playerDiv);
+                const nameInput = document.getElementById(`name-${number}`);
+                const scoreSpan = document.getElementById(`score-number-${number}`);
+
+                return {
+                    name: nameInput.value,
+                    confirmed: nameInput.disabled,
+                    score: scoreSpan ? parseInt(scoreSpan.innerHTML) : 0
+                };
+            });
+
+            const revealed = Array.from(document.getElementsByName("song-panel"))
+                .filter((div) => div.classList.contains("revealed"))
+                .map((div) => div.id);
+
+            const state = { signature: getSongSignature(), players, revealed };
+            localStorage.setItem(getStorageKey(), JSON.stringify(state));
+        }
+
+        function resetGame() {
+            if (!confirm("Reset all players and revealed songs?")) return;
+            localStorage.removeItem(getStorageKey());
+            location.reload();
+        }
+
+        function loadGameState() {
+            const raw = localStorage.getItem(getStorageKey());
+            if (!raw) return;
+
+            let state;
+            try {
+                state = JSON.parse(raw);
+            } catch (err) {
+                localStorage.removeItem(getStorageKey());
+                return;
+            }
+
+            if (!state || state.signature !== getSongSignature()) {
+                localStorage.removeItem(getStorageKey());
+                return;
+            }
+
+            isRestoringState = true;
+
+            state.revealed.forEach(markRevealed);
+
+            state.players.forEach((player) => {
+                const playerDiv = addPlayer();
+                const number = getPlayerNumber(playerDiv);
+
+                document.getElementById(`name-${number}`).value = player.name;
+
+                if (player.confirmed) {
+                    confirmPlayer(document.getElementById(`confirm-player-${number}`));
+                    document.getElementById(`score-number-${number}`).innerHTML = player.score;
+                }
+            });
+
+            isRestoringState = false;
+        }
+
+        window.addEventListener("load", loadGameState);
 
         function setVolume(percent) {
             player.setVolume(percent);


### PR DESCRIPTION
## Summary
- The generated trivia game now persists players, scores, and revealed songs to `localStorage` on every meaningful action, restoring them on refresh/reopen -- previously a refresh mid-game silently lost everything.
- The storage key is derived from a signature of the song-list IDs rather than being fixed or path-based. This matters because Chromium shares one `localStorage` bucket across *every* `file://` page regardless of directory or filename -- verified this empirically. A fixed key would let two different generated trivials opened in the same browser clobber each other's state; deriving the key from content instead means renaming/moving the file doesn't lose state, and different games naturally get separate storage slots.
- A regenerated file at the same output path with a different song list is detected via signature mismatch and starts with a clean slate instead of resurrecting stale/mismatched players.
- Added a themed "Reset Game" button (with a confirm prompt) next to "Add Player" for starting over intentionally.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build:win` produces a working portable exe
- [x] Verified via Playwright: score/name/revealed-song state survives a page reload
- [x] Verified via Playwright: a corrupted/mismatched signature clears state instead of restoring wrong data
- [x] Verified via Playwright: two differently-rendered trivia files opened in the same browser context don't clobber each other's saved state
- [ ] Manual smoke test of the built exe by the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)