### PR TITLE
Player rename/remove with confirmation, and per-round points tracking

### DIFF
--- a/src/main/trivial-generator/trivial.css.ejs
+++ b/src/main/trivial-generator/trivial.css.ejs
@@ -1460,13 +1460,13 @@
         background: rgba(244, 236, 216, 0.15);
     }
 
-    #modal-overlay .bg-white {
+    [id$="modal-overlay"] .bg-white {
         background: var(--panel) !important;
         border: 2px solid var(--gold);
     }
 
-    #modal-overlay h3,
-    #modal-overlay .text-gray-900 {
+    [id$="modal-overlay"] h3,
+    [id$="modal-overlay"] .text-gray-900 {
         font-family: "Anton", sans-serif;
         text-transform: uppercase;
         letter-spacing: 0.03em;
@@ -1501,7 +1501,85 @@
         background: var(--gold-dim) !important;
     }
 
-    #modal-overlay.bg-gray-600 {
+    [id$="modal-overlay"].bg-gray-600 {
         background-color: rgba(11, 18, 41, 0.75) !important;
+    }
+
+    .modal-cancel-btn {
+        flex: 1;
+        font-family: "Anton", sans-serif;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        border: 2px solid var(--panel-border);
+        background: transparent !important;
+        color: var(--cream) !important;
+        transition: border-color 0.12s ease;
+    }
+
+    .modal-cancel-btn:hover {
+        border-color: var(--cream);
+    }
+
+    .modal-danger-btn {
+        flex: 1;
+        font-family: "Anton", sans-serif;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        background: var(--crimson) !important;
+        color: var(--cream) !important;
+        transition: background 0.12s ease;
+    }
+
+    .modal-danger-btn:hover {
+        background: #c22b3f !important;
+    }
+
+    .modal-message {
+        margin-top: 1rem;
+        text-align: center;
+    }
+
+    .confirm-modal-actions {
+        display: flex;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+    }
+
+    .btn-row {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+    }
+
+    .player-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+    }
+
+    .player-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+    }
+
+    .player-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+    }
+
+    .round-points {
+        font-family: "Archivo", sans-serif;
+        font-weight: 700;
+        font-size: 0.7rem;
+        color: rgba(244, 236, 216, 0.4);
+        white-space: nowrap;
+    }
+
+    .round-points-awarded {
+        color: var(--gold);
     }
 </style>

--- a/src/main/trivial-generator/trivial.player.ejs
+++ b/src/main/trivial-generator/trivial.player.ejs
@@ -9,18 +9,27 @@
                 parseInt(Array.from(players).at(-1).id.split("-").at(-1)) + 1;
         }
 
-        const newPlayer = `<div id="player-${newPlayerNumber}" name="player" class="flex justify-start border gap-0 border-black rounded w-full bg-sky-300 p-2">
+        const newPlayer = `<div id="player-${newPlayerNumber}" name="player" class="player-card border border-black rounded w-full bg-sky-300 p-2">
+            <div class="player-row">
             <div class="w-9/12" id="div-name-${newPlayerNumber}">
             <input id="name-${newPlayerNumber}" type="text" placeholder="New player" class="player-name-input px-1 bg-transparent w-full" onkeydown="enterName(event);">
             </div>
-            <div>
+            <div id="pre-confirm-actions-${newPlayerNumber}" class="player-actions flex-shrink-0">
             <button class="player-icon-btn" onclick="confirmPlayer(this);" id="confirm-player-${newPlayerNumber}">✅</button>
             <button class="player-icon-btn" onclick="deletePlayer(this);" id="delete-player-${newPlayerNumber}">❌</button>
             </div>
-            <div id="score-player-${newPlayerNumber}" class="flex justify-end gap-0 w-24 box-border" style="display:none">
+            <div id="post-confirm-name-actions-${newPlayerNumber}" class="player-actions flex-shrink-0" style="display:none">
+            <button class="player-icon-btn" onclick="editPlayerName(this);" id="edit-player-${newPlayerNumber}" title="Rename">✏️</button>
+            <button class="player-icon-btn" onclick="requestDeletePlayer(this);" id="remove-player-${newPlayerNumber}" title="Remove player">🗑️</button>
+            </div>
+            </div>
+            <div id="score-row-${newPlayerNumber}" class="player-row" style="display:none">
+            <span id="round-points-${newPlayerNumber}" class="round-points" data-round-score="0">No points</span>
+            <div class="flex gap-0">
             <button id="score-minus-${newPlayerNumber}" class="score-btn score-btn-minus w-5 h-6 rounded-tl rounded-bl" onclick="editScore(this, 'remove');"> - </button>
             <span id="score-number-${newPlayerNumber}" class="score-number text-center w-8 h-6"> 0 </span>
             <button id="score-plus-${newPlayerNumber}" class="score-btn score-btn-plus w-5 h-6 rounded-tr rounded-br" onclick="editScore(this, 'add');"> + </button>
+            </div>
             </div>
         </div>`;
         playersDiv.insertAdjacentHTML("beforeend", newPlayer);
@@ -60,13 +69,34 @@
         document.getElementById(`div-name-${playerNumber}`).style.width =
             "fit-content";
 
-        button.remove();
-        document.getElementById(`delete-player-${playerNumber}`).remove();
-
-        const scoreDiv = document.getElementById(`score-player-${playerNumber}`);
-        scoreDiv.style.display = "flex";
+        document.getElementById(`pre-confirm-actions-${playerNumber}`).style.display = "none";
+        document.getElementById(`post-confirm-name-actions-${playerNumber}`).style.display = "flex";
+        document.getElementById(`score-row-${playerNumber}`).style.display = "flex";
 
         saveGameState();
+    }
+
+    function editPlayerName(button) {
+        const playerNumber = getPlayerNumber(button);
+        const nameInput = document.getElementById(`name-${playerNumber}`);
+
+        nameInput.disabled = false;
+        document.getElementById(`div-name-${playerNumber}`).style.width = "";
+
+        document.getElementById(`post-confirm-name-actions-${playerNumber}`).style.display = "none";
+        document.getElementById(`pre-confirm-actions-${playerNumber}`).style.display = "flex";
+
+        nameInput.focus();
+        nameInput.select();
+    }
+
+    function requestDeletePlayer(button) {
+        const playerNumber = getPlayerNumber(button);
+        const name = document.getElementById(`name-${playerNumber}`).value || "this player";
+
+        openConfirmModal(`Remove ${name}? This can't be undone.`, () => {
+            deletePlayer(button);
+        });
     }
 
     function deletePlayer(button) {
@@ -80,11 +110,14 @@
     function editScore(button, mode) {
         const playerNumber = getPlayerNumber(button);
         const scoreNumber = document.getElementById(`score-number-${playerNumber}`);
+        const roundPoints = document.getElementById(`round-points-${playerNumber}`);
 
         const score = parseInt(scoreNumber.innerHTML);
         const newScore = mode == "add" ? score + 1 : score - 1;
-
         scoreNumber.innerHTML = newScore;
+
+        const roundValue = parseInt(roundPoints.dataset.roundScore) + (mode == "add" ? 1 : -1);
+        updateRoundPoints(roundPoints, roundValue);
 
         saveGameState();
     }

--- a/src/main/trivial-generator/trivial.template.ejs
+++ b/src/main/trivial-generator/trivial.template.ejs
@@ -36,6 +36,24 @@
         </div>
     </div>
 
+    <!--Confirm Modal-->
+    <div class="fixed hidden inset-0 z-20 bg-gray-600 bg-opacity-50 h-full w-full" id="confirm-modal-overlay">
+        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+            <div class="modal-body mt-3">
+                <h3 class="text-lg text-center leading-6 font-medium text-gray-900">Confirm</h3>
+                <p id="confirm-modal-message" class="modal-message"></p>
+                <div class="confirm-modal-actions">
+                    <button id="confirm-modal-cancel-btn" class="modal-cancel-btn px-4 py-2 rounded-md">
+                        Cancel
+                    </button>
+                    <button id="confirm-modal-confirm-btn" class="modal-danger-btn px-4 py-2 rounded-md">
+                        Remove
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Content -->
     <h1 class="trivial-title text-3xl ml-5 mt-5"><%= trivialType.charAt(0).toUpperCase() + trivialType.slice(1) %> Trivial</h1>
     <div class="flex justify-around w-full py-0 px-5 mt-5 gap-5 overflow-y-auto">
@@ -64,7 +82,7 @@
             </div>
 
             <div id="div-scoreboard" class="w-full">
-                <div class="flex gap-2 justify-center">
+                <div class="btn-row">
                     <button
                         class="add-player-btn w-28 p-1 flex border border-black shadow-sm text-sm font-medium rounded-md text-white bg-teal-500 hover:bg-teal-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
                         onclick="addPlayer()">
@@ -254,6 +272,8 @@
             currentId = songId;
             currentEmbeddable = songPanel.dataset.embeddable === "true";
             currentError = songPanel.dataset.error === "true";
+
+            resetRoundPoints();
         }
 
         function removeFocus(songId) {
@@ -299,6 +319,53 @@
         }
 
         // ************
+        //  ROUND POINTS
+        // ************
+        // Tracks points awarded since the current song started, so the host
+        // can visually confirm every player was scored before moving on.
+        function updateRoundPoints(roundPointsSpan, value) {
+            roundPointsSpan.dataset.roundScore = value;
+
+            if (value === 0) {
+                roundPointsSpan.textContent = "No points";
+                roundPointsSpan.classList.remove("round-points-awarded");
+            } else {
+                const sign = value > 0 ? "+" : "";
+                const unit = Math.abs(value) === 1 ? "point" : "points";
+                roundPointsSpan.textContent = `${sign}${value} ${unit}`;
+                roundPointsSpan.classList.add("round-points-awarded");
+            }
+        }
+
+        function resetRoundPoints() {
+            document.querySelectorAll(".round-points").forEach((span) => updateRoundPoints(span, 0));
+            saveGameState();
+        }
+
+        // ************
+        //  CONFIRM MODAL
+        // ************
+        let confirmModalCallback = null;
+
+        function openConfirmModal(message, onConfirm) {
+            document.getElementById("confirm-modal-message").textContent = message;
+            confirmModalCallback = onConfirm;
+            document.getElementById("confirm-modal-overlay").style.display = "block";
+        }
+
+        function closeConfirmModal() {
+            document.getElementById("confirm-modal-overlay").style.display = "none";
+            confirmModalCallback = null;
+        }
+
+        document.getElementById("confirm-modal-cancel-btn").onclick = closeConfirmModal;
+        document.getElementById("confirm-modal-confirm-btn").onclick = () => {
+            const callback = confirmModalCallback;
+            closeConfirmModal();
+            if (callback) callback();
+        };
+
+        // ************
         //  PERSISTENCE
         // ************
         // Chromium shares one localStorage bucket across every file:// page
@@ -322,11 +389,13 @@
                 const number = getPlayerNumber(playerDiv);
                 const nameInput = document.getElementById(`name-${number}`);
                 const scoreSpan = document.getElementById(`score-number-${number}`);
+                const roundSpan = document.getElementById(`round-points-${number}`);
 
                 return {
                     name: nameInput.value,
                     confirmed: nameInput.disabled,
-                    score: scoreSpan ? parseInt(scoreSpan.innerHTML) : 0
+                    score: scoreSpan ? parseInt(scoreSpan.innerHTML) : 0,
+                    roundScore: roundSpan ? parseInt(roundSpan.dataset.roundScore) : 0
                 };
             });
 
@@ -374,6 +443,10 @@
                 if (player.confirmed) {
                     confirmPlayer(document.getElementById(`confirm-player-${number}`));
                     document.getElementById(`score-number-${number}`).innerHTML = player.score;
+                    updateRoundPoints(
+                        document.getElementById(`round-points-${number}`),
+                        player.roundScore || 0
+                    );
                 }
             });
 


### PR DESCRIPTION
## Summary
- Confirmed players can now be renamed (pencil icon, re-enables the name field) or removed (trash icon) via a themed confirmation modal -- previously there was no way to fix a typo or remove a player once confirmed short of resetting the whole game.
- A new-in-progress (not-yet-confirmed) player still cancels instantly with no modal, since nothing has been committed for it yet.
- Added a per-player "round points" badge ("No points" / "+2 points" / etc.) tracking points awarded since the current song started. It resets when a new song is selected, so the host can visually scan for anyone who wasn't scored before moving on -- the original ask behind this PR.
- Restructured each player row into two stacked lines after discovering the single-row layout crushed the name field to ~36px once round-points + rename/remove controls were added -- confirmed via computed-style measurement, not just a screenshot glance.
- Replaced several newly-introduced Tailwind utility combinations (`gap-*`, `flex-1`, `justify-between`, `mt-6`, etc.) with dedicated theme classes after discovering they were silent no-ops: `trivial.css.ejs`'s base layer is a frozen precompile of only the utility classes the *original* templates referenced, so any utility invented after the fact never renders, regardless of whether it's "real" Tailwind. Also retroactively fixed the same issue in the previously-merged Reset Game button row.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build:win` produces a working portable exe
- [x] Verified via Playwright + computed-style assertions (not just screenshots, after getting burned once in this same PR): confirm/rename/delete flows, round-points reset-on-new-song while total score persists, and state survives a reload
- [ ] Manual smoke test of the built exe by the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)