### PR TITLE
Add reveal/un-reveal toggle, and fix scrolling for large song lists

### DIFF
--- a/src/main/trivial-generator/trivial.css.ejs
+++ b/src/main/trivial-generator/trivial.css.ejs
@@ -1111,7 +1111,7 @@
     }
 
     html {
-        height: 100%;
+        min-height: 100%;
         background:
             radial-gradient(ellipse 120% 70% at 50% -10%, rgba(240, 176, 46, 0.16), transparent 60%),
             radial-gradient(ellipse 100% 60% at 85% 110%, rgba(224, 52, 74, 0.12), transparent 55%),
@@ -1543,6 +1543,10 @@
         display: flex;
         gap: 0.75rem;
         margin-top: 1.5rem;
+    }
+
+    #leftPanel {
+        align-self: flex-start;
     }
 
     .btn-row {

--- a/src/main/trivial-generator/trivial.template.ejs
+++ b/src/main/trivial-generator/trivial.template.ejs
@@ -8,7 +8,7 @@
     <title><%=  trivialType.charAt(0).toUpperCase() + trivialType.slice(1) %> Trivial</title>
 </head>
 
-<body class="overflow-y-hidden">
+<body>
     <!--Overlay Effect-->
     <div class="fixed hidden inset-0 z-10 bg-gray-600 bg-opacity-50 h-full w-full" id="modal-overlay">
 
@@ -56,7 +56,7 @@
 
     <!-- Content -->
     <h1 class="trivial-title text-3xl ml-5 mt-5"><%= trivialType.charAt(0).toUpperCase() + trivialType.slice(1) %> Trivial</h1>
-    <div class="flex justify-around w-full py-0 px-5 mt-5 gap-5 overflow-y-auto">
+    <div class="flex justify-around w-full py-0 px-5 mt-5 gap-5">
         <div id="leftPanel" class="w-[250px] px-0 mr-1 flex-shrink-0 sticky top-0">
             <div id="div-controls" class="border rounded border-black w-full px-2 mb-6 h-32 bg-sky-300">
                 <div id="time" class="pt-1 text-lg font-bold">
@@ -69,7 +69,7 @@
                 <div id="div-buttons" class="flex mt-2 justify-evenly">
                     <button id="btn-play" onclick="togglePause();">▶</button>
                     <button id="btn-stop" onclick="stop();">⏹</button>
-                    <button id="btn-reveal" onclick="reveal();">🔎</button>
+                    <button id="btn-reveal" onclick="toggleReveal();" title="Reveal answer">🔎</button>
                     <button id="btn-info" onclick="infoModal(currentId);">ℹ️</button>
                 </div>
                 <input id="volume-range" class="w-full mt-3" type="range" min="0" max="100" step="1"
@@ -101,7 +101,7 @@
                 </div>
             </div>
         </div>
-        <div id="mainPanel" class="w-[88%] px-4 mb-3 h-[80vh]">
+        <div id="mainPanel" class="w-[88%] px-4 mb-3">
             <div id="song-panel-div" class="flex justify-start w-full flex-wrap gap-5">
                 <% 
                 const DIFFICULTY_COLORS = {
@@ -274,15 +274,16 @@
             currentError = songPanel.dataset.error === "true";
 
             resetRoundPoints();
+            updateRevealButton(songId);
         }
 
         function removeFocus(songId) {
             if (!songId) {
                 return;
             }
-            
+
             const songDiv = document.getElementById(songId)
-            
+
             songDiv.classList.remove("border-8");
             songDiv.classList.add("border-4");
 
@@ -296,6 +297,8 @@
             currentId = "";
             currentEmbeddable = null;
             currentError = null;
+
+            updateRevealButton(null);
         }
 
         function markRevealed(songId) {
@@ -310,10 +313,36 @@
                 "url('https://img.youtube.com/vi/" + songId + "/hqdefault.jpg')";
         }
 
-        function reveal() {
+        function unmarkRevealed(songId) {
+            const div = document.getElementById(songId);
+            if (!div) return;
+
+            const answer = document.getElementById(`anime-${songId}`);
+            answer.classList.add("hidden");
+
+            div.classList.remove("revealed");
+            div.style.backgroundImage = "";
+        }
+
+        function updateRevealButton(songId) {
+            const btn = document.getElementById("btn-reveal");
+            const div = songId ? document.getElementById(songId) : null;
+            const isRevealed = div ? div.classList.contains("revealed") : false;
+
+            btn.textContent = isRevealed ? "🙈" : "🔎";
+            btn.title = isRevealed ? "Hide answer" : "Reveal answer";
+        }
+
+        function toggleReveal() {
             if (currentId == "") return;
 
-            markRevealed(currentId);
+            const div = document.getElementById(currentId);
+            if (div.classList.contains("revealed")) {
+                unmarkRevealed(currentId);
+            } else {
+                markRevealed(currentId);
+            }
+
             removeFocus(currentId);
             saveGameState();
         }


### PR DESCRIPTION
## Summary
- Reveal is now a toggle: the 🔎 button switches to 🙈 and un-reveals the currently-selected song (re-hides the answer, clears the thumbnail) when it's already revealed -- lets the host recover from an accidental reveal instead of it being permanent for the rest of the game.
- Fixed song cards being cut off with no way to scroll and reach them on large playlists. Root cause was `<body class="overflow-y-hidden">` (present before this session) with no matching `overflow` on `<html>` -- per the CSS spec, that combination propagates body's overflow to become the *entire viewport's* scroll behavior, killing page scroll outright regardless of any inner container's own overflow setting.
- Once page scroll was restored, a second bug surfaced: the sticky sidebar stopped sticking near the bottom of long lists, because as a flex item it stretches (default `align-items: stretch`) to match the song grid's height -- a sticky element only stays pinned while its own box is still in view, so a sidebar stretched as tall as the whole grid unsticks right as you approach the end. Fixed with `align-self: flex-start`.
- Restoring page scroll also re-exposed a background-seam bug: `html`'s background only painted within `height: 100%` (exactly one viewport), so content past that boundary showed the browser's default background instead. Applied the same fix `body` already had: `min-height: 100%` so the background always covers the actual (now taller) content.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build:win` produces a working portable exe
- [x] Verified via Playwright: reveal/un-reveal toggles the button icon and tile state correctly in both directions
- [x] Verified via Playwright: a 40-song list overflows correctly, scrolling reaches every card, the sidebar stays pinned at `top: 0` through the full scroll range, and there's no background seam anywhere
- [x] Confirmed by the user on the rebuilt exe (both the scroll fix and the background-seam fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)