### PR TITLE
Split "Band - Song" YouTube titles into band/name on playlist import

### DIFF
--- a/src/renderer/src/pages/list-editor/list-editor.root.tsx
+++ b/src/renderer/src/pages/list-editor/list-editor.root.tsx
@@ -52,6 +52,19 @@ function buildDefaultRow(type: ListType): Song {
   throw new Error("Invalid type!");
 }
 
+function parseYoutubeTitle(title: string): { band: string; name: string } {
+  const separatorIndex = title.indexOf(" - ");
+
+  if (separatorIndex === -1) {
+    return { band: "", name: title };
+  }
+
+  return {
+    band: title.slice(0, separatorIndex).trim(),
+    name: title.slice(separatorIndex + " - ".length).trim()
+  };
+}
+
 function ListEditor() {
   const { originalListPath, originalOutputDir, mode } = useLocation().state as ListEditorProps;
 
@@ -101,8 +114,15 @@ function ListEditor() {
         const newRow = buildDefaultRow(listType);
 
         newRow.id = song.id;
-        newRow.name = song.title;
         newRow.link = `https://youtu.be/${song.id}`;
+
+        if ("band" in newRow) {
+          const { band, name } = parseYoutubeTitle(song.title);
+          newRow.band = band;
+          newRow.name = name;
+        } else {
+          newRow.name = song.title;
+        }
 
         return newRow;
       });


### PR DESCRIPTION
## Summary
- Most YouTube uploads follow a "Band - Song Name" title convention. Splitting on the first " - " and filling both the `band` and `name` fields saves manually re-typing the band for every imported song.
- Splits on the *first* occurrence only, so a title like "Artist - Song - Remix" becomes band "Artist", name "Song - Remix" rather than losing anything after a second dash.
- Only applies to list types that actually have a `band` field (anime, normie). Game lists have no `band` field, so titles are kept whole as before -- splitting there would silently drop the prefix (e.g. the game name in "Persona 5 - Life Will Change") with nowhere to put it.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build:win` produces a working portable exe
- [x] Confirmed by the user on the rebuilt exe

🤖 Generated with [Claude Code](https://claude.com/claude-code)